### PR TITLE
Upgraded libxml-ruby version so it compiles on Ubuntu 13.04.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     cpsms (0.1.5)
       httparty (~> 0.10.2)
-      libxml-ruby (~> 2.2.2)
+      libxml-ruby (~> 2.6.0)
 
 GEM
   remote: http://rubygems.org/
@@ -21,12 +21,12 @@ GEM
     httparty (0.10.2)
       multi_json (~> 1.0)
       multi_xml (>= 0.5.2)
-    libxml-ruby (2.2.2)
+    libxml-ruby (2.6.0)
     metaclass (0.0.1)
     minitest (2.11.2)
     mocha (0.10.5)
       metaclass (~> 0.0.1)
-    multi_json (1.6.1)
+    multi_json (1.7.3)
     multi_xml (0.5.3)
     rake (0.9.2.2)
     thor (0.14.6)

--- a/cpsms.gemspec
+++ b/cpsms.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     s.add_dependency('libxml-jruby',  '~> 1.0.0')
     s.add_dependency('jruby-openssl', '~> 0.7.6')
   else
-    s.add_dependency('libxml-ruby',   '~> 2.2.2')
+    s.add_dependency('libxml-ruby',   '~> 2.6.0')
   end
 
   s.add_development_dependency('minitest',       '~> 2.11.2')


### PR DESCRIPTION
The gem "libxml-ruby" version "2.2.2" does not compile on Ubuntu 13.04. Upgrading to the newest version "2.6.0" does not seem to break any tests, so it would be nice, if you accepted this and upgraded the gem.

Then I can get Naoshi up running on Ubuntu 13.04.
