### PR TITLE
Less strict dependencies and multiple Ruby versions testing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     cpsms (0.1.6)
-      httparty (~> 0.10.2)
-      libxml-ruby (~> 2.6.0)
+      httparty (>= 0.10.2)
+      libxml-ruby (>= 2.6.0)
 
 GEM
   remote: https://rubygems.org/
@@ -19,15 +19,15 @@ GEM
       thor (~> 0.14.6)
     guard-minitest (0.4.0)
       guard (~> 0.4)
-    httparty (0.10.2)
-      multi_json (~> 1.0)
+    httparty (0.13.3)
+      json (~> 1.8)
       multi_xml (>= 0.5.2)
-    libxml-ruby (2.6.0)
+    json (1.8.2)
+    libxml-ruby (2.8.0)
     metaclass (0.0.1)
     minitest (2.11.2)
     mocha (0.10.5)
       metaclass (~> 0.0.1)
-    multi_json (1.10.1)
     multi_xml (0.5.5)
     rake (0.9.2.2)
     safe_yaml (1.0.4)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Gem Version](https://badge.fury.io/rb/cpsms.svg)](http://badge.fury.io/rb/cpsms)
-[![Build Status](https://circleci.com/gh/gfish/cpsms/tree/master.svg?style=shield)](https://circleci.com/gh/gfish/cpsms/tree/master)
+[![Build Status](https://circleci.com/gh/dipth/cpsms/tree/master.svg?style=shield)](https://circleci.com/gh/dipth/cpsms/tree/master)
 
 # CPSMS
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Gem Version](https://badge.fury.io/rb/cpsms.svg)](http://badge.fury.io/rb/cpsms)
 [![Build Status](https://circleci.com/gh/gfish/cpsms/tree/master.svg?style=shield)](https://circleci.com/gh/gfish/cpsms/tree/master)
 
 # CPSMS

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A wrapper for the cpsms.dk API.
 
 It will allow you to easily send SMS messages through the API from your Ruby applications.
 
-[![Build Status](https://secure.travis-ci.org/dipth/cpsms.png?branch=master)](http://travis-ci.org/dipth/cpsms)
+[![Build Status](https://circleci.com/gh/gfish/cpsms/tree/master.svg?style=svg&circle-token=a13b3c3f30bf5a75d9dd20cf2a568e20760dc9b4)](https://circleci.com/gh/gfish/cpsms/tree/master)
 
 # Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
+[![Build Status](https://circleci.com/gh/gfish/cpsms/tree/master.svg?style=shield)](https://circleci.com/gh/gfish/cpsms/tree/master)
+
 # CPSMS
 
 A wrapper for the cpsms.dk API.
 
 It will allow you to easily send SMS messages through the API from your Ruby applications.
-
-[![Build Status](https://circleci.com/gh/gfish/cpsms/tree/master.svg?style=svg&circle-token=a13b3c3f30bf5a75d9dd20cf2a568e20760dc9b4)](https://circleci.com/gh/gfish/cpsms/tree/master)
 
 # Prerequisites
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+dependencies:
+  override:
+    - rvm-exec 1.9.3 bundle install
+    - rvm-exec 2.1.2 bundle install
+    - rvm-exec 2.2.0 bundle install
+
+test:
+  override:
+    - rvm-exec 1.9.3 bundle exec rake
+    - rvm-exec 2.1.2 bundle exec rake
+    - rvm-exec 2.2.0 bundle exec rake

--- a/cpsms.gemspec
+++ b/cpsms.gemspec
@@ -18,14 +18,14 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('httparty',      '~> 0.10.2')
+  s.add_dependency('httparty',      '>= 0.10.2')
 
   case RUBY_PLATFORM
   when 'java'
-    s.add_dependency('libxml-jruby',  '~> 1.0.0')
-    s.add_dependency('jruby-openssl', '~> 0.7.6')
+    s.add_dependency('libxml-jruby',  '>= 1.0.0')
+    s.add_dependency('jruby-openssl', '>= 0.7.6')
   else
-    s.add_dependency('libxml-ruby',   '~> 2.6.0')
+    s.add_dependency('libxml-ruby',   '>= 2.6.0')
   end
 
   s.add_development_dependency('minitest',       '~> 2.11.2')

--- a/cpsms.gemspec
+++ b/cpsms.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = '>= 1.9.3'
+
   s.add_dependency('httparty',      '>= 0.10.2')
 
   case RUBY_PLATFORM


### PR DESCRIPTION
- Less strict set of dependencies, for allowing project being more up-to-date
- Switched Travis out with CircleCI
- Updated Readme to contain integrated status icons
- Now requires Ruby 1.9.3